### PR TITLE
Bump minimum macOS version to fix compile error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "DirectoryWatcher",
-	platforms: [.macOS(.v10_12),
+	platforms: [.macOS(.v10_15),
 				.iOS(.v13),
 				.tvOS(.v13),
 				.watchOS(.v6)],


### PR DESCRIPTION
Thank you for this project 🙇🏻 
This tiny PR bumps the minimum macOS version in Package.swift to 10.15 due to the use of `PassthroughSubject`:

```
.../DirectoryWatcher/Sources/DirectoryWatcher/DirectoryWatcher.swift:27:34: 'PassthroughSubject' is only available in macOS 10.15 or newer
```
